### PR TITLE
Indent lines after background the same as scenario and feature

### DIFF
--- a/feature-mode.el
+++ b/feature-mode.el
@@ -225,6 +225,9 @@
 (defun feature-scenario-re (language)
   (cdr (assoc 'scenario (cdr (assoc language feature-keywords-per-language)))))
 
+(defun feature-background-re (language)
+  (cdr (assoc 'background (cdr (assoc language feature-keywords-per-language)))))
+
 ;;
 ;; Variables
 ;;
@@ -251,7 +254,8 @@
         (forward-line -1))
       (+ (current-indentation)
          (if (or (looking-at (feature-feature-re (feature-detect-language)))
-                 (looking-at (feature-scenario-re (feature-detect-language))))
+                 (looking-at (feature-scenario-re (feature-detect-language)))
+                 (looking-at (feature-background-re (feature-detect-language))))
              feature-indent-offset 0)))))
 
 (defun feature-indent-line ()


### PR DESCRIPTION
Howdy :)

When using cucumber.el today I noticed that it wasn't letting me indent my background section the way the cucumber wiki shows:

https://github.com/cucumber/cucumber/wiki/Background

Lines below a Background: section should be indented.

This change fixes this. Let me know if anything else should be done, or if this is the wrong approach.
