### PR TITLE
Replaced a call to obsolete function

### DIFF
--- a/feature-mode.el
+++ b/feature-mode.el
@@ -461,7 +461,7 @@ are loaded on startup.  If nil, don't load snippets.")
          (matched? (string-match "^\\(.+\\):\\([0-9]+\\)$" file-and-line)))
     (if matched?
         (let ((file    (format "%s/%s" root (match-string 1 file-and-line)))
-              (line-no (string-to-int (match-string 2 file-and-line))))
+              (line-no (string-to-number (match-string 2 file-and-line))))
           (find-file file)
           (goto-char (point-min))
           (forward-line (1- line-no)))


### PR DESCRIPTION
This was the error that would be produced when bytecompiling the feature-mode.el:

In feature-goto-step-definition:
feature-mode.el:464:55:Warning: `string-to-int' is an obsolete function
(as of 22.1); use`string-to-number' instead.

Nothing critical, but it would be good to be able to compile the mode silently

Thank you
