### PR TITLE
Change all variables to be in group feature-mode

### DIFF
--- a/feature-mode.el
+++ b/feature-mode.el
@@ -255,11 +255,11 @@
 
 (defcustom feature-indent-level 2
   "Indentation of feature statements"
-  :type 'integer :group 'feature)
+  :type 'integer :group 'feature-mode)
 
 (defcustom feature-indent-offset 2
   "*Amount of offset per level of indentation."
-  :type 'integer :group 'feature)
+  :type 'integer :group 'feature-mode)
 
 (defun feature-compute-indentation ()
   "Calculate the maximum sensible indentation for the current line."


### PR DESCRIPTION
Half of the customizable variables were in group `feature`, and half in group `feature-mode`.  I changed them all to `feature-mode` since that seemed less ambiguous.
