### PR TITLE
Font locking fix.

### DIFF
--- a/feature-mode.el
+++ b/feature-mode.el
@@ -187,7 +187,7 @@
                   (".*" nil nil (0 font-lock-type-face t)))
     (background . (0 font-lock-keyword-face))
     (scenario     (0 font-lock-keyword-face)
-                  (".*" nil nil (0 font-lock-function-name-face t)))
+                  (".*" nil nil (0 font-lock-function-name-face nil)))
     (scenario_outline
                   (0 font-lock-keyword-face)
                   (".*" nil nil (0 font-lock-function-name-face t)))


### PR DESCRIPTION
The font locking of "Scenario Outline" was being stepped on by that of "Scenario".   This resulted in "Outline" being marked with font-lock-function-name-face instead of font-lock-keyword-face.
