### PR TITLE
Font locking for example placeholders

### DIFF
--- a/feature-mode.el
+++ b/feature-mode.el
@@ -197,6 +197,7 @@
     (but        . font-lock-keyword-face)
     (and        . font-lock-keyword-face)
     (examples   . font-lock-keyword-face)
+    ("<.*>"     . font-lock-variable-name-face)
     ("^ *@.*"   . font-lock-preprocessor-face)
     ("^ *#.*"     0 font-lock-comment-face t)))
 


### PR DESCRIPTION
I added some font-locking for example placeholders, ie <variable>.
