### PR TITLE
Stop requiring that Rakefile exists

### DIFF
--- a/feature-mode.el
+++ b/feature-mode.el
@@ -93,7 +93,7 @@
   :type 'boolean
   :group 'feature-mode)
 
-(defcustom feature-root-marker-file-name "Rakefile"
+(defcustom feature-root-marker-file-name "features"
   "file to look for to find the project root."
   :group 'feature-mode
   :type  'string)


### PR DESCRIPTION
This PR changes the following:
1. We let the user choose what file to use (the "marker") to determine the project root. This allows people to use `Rakefile`, `.git` or whatever they thing it's best.
2. We change the default marker to `features` as I think it's almost certain that this directory will exists if we're using `feature-mode`. 
