### PR TITLE
Scroll the compilation window properly

### DIFF
--- a/feature-mode.el
+++ b/feature-mode.el
@@ -443,12 +443,12 @@ are loaded on startup.  If nil, don't load snippets.")
                          feature-file
                        feature-default-directory)))
     (ansi-color-for-comint-mode-on)
-    (let ((default-directory (feature-project-root)))
+    (let ((default-directory (feature-project-root))
+          (compilation-scroll-output t))
       (if feature-use-rvm
           (rvm-activate-corresponding-ruby))
       (compile (concat (replace-regexp-in-string "\{options\}" opts-str
-                        (replace-regexp-in-string "\{feature\}" feature-arg feature-cucumber-command))) t)))
-  (end-of-buffer-other-window 0))
+                        (replace-regexp-in-string "\{feature\}" feature-arg feature-cucumber-command))) t))))
 
 (defun feature-escape-scenario-name (scenario-name)
   "Escapes all the characaters in a scenario name that mess up using in the -n options"


### PR DESCRIPTION
The call to `end-of-buffer-other-window` in the current code almost always scrolls the wrong window for me.
