### PR TITLE
Fix support/find_step.rb script

### DIFF
--- a/support/find_step.rb
+++ b/support/find_step.rb
@@ -52,7 +52,7 @@ class StepParser
     when :iter
       child_sexp = sexp[1]
       return unless child_sexp[0] == :call && @keywords.include?(child_sexp[2])
-      regexp = child_sexp[3][1] && child_sexp[3][1][1]
+      regexp = child_sexp[3][1]
       @steps << Step.new(regexp, file, child_sexp.line)
     else
       sexp.each do |child_sexp|


### PR DESCRIPTION
The major problem was that in case when ruby parser reused, it does not reset line number counter. Which means the script is useless, because of pointing beyond the file end.

Other fixes mostly related to unlocking ruby_parser gem and use the recent stable version
