### PR TITLE
Use line number instead of scenario name when run it

### DIFF
--- a/feature-mode.el
+++ b/feature-mode.el
@@ -447,21 +447,11 @@ are loaded on startup.  If nil, don't load snippets.")
 (defun feature-scenario-name-re (language)
   (concat (feature-scenario-re (feature-detect-language)) "\\( Outline:?\\)?[[:space:]]+\\(.*\\)$"))
 
-(defun feature-scenario-name-at-pos (&optional pos)
-  "Returns the name of the scenario at the specified position. if pos is not specified the current buffer location will be used."
-  (interactive)
-  (let ((start (or pos (point))))
-    (save-excursion
-      (end-of-line)
-      (unless (re-search-backward (feature-scenario-name-re (feature-detect-language)) nil t)
-        (error "Unable to find an scenario"))
-      (match-string-no-properties 3))))
-
 (defun feature-verify-scenario-at-pos (&optional pos)
   "Run the scenario defined at pos.  If post is not specified the current buffer location will be used."
   (interactive)
   (feature-run-cucumber
-   (list "-n" (shell-quote-argument (feature-scenario-name-at-pos)) )
+   (list "-l" (number-to-string (line-number-at-pos)))
    :feature-file (buffer-file-name)))
 
 (defun feature-verify-all-scenarios-in-buffer ()


### PR DESCRIPTION
Line number is more robust because cucumber does pattern matching for
'-n' argument, so if you happened to have scenario, which name is
happened to be part of another scenario in the same file, feature-mode
will run them both. Another case is that it is not possible to run on
specific example of scenario outline. With line number argument, it is
possible, just set cursor to the row in the examples table.
