### PR TITLE
Only set require-final-newline true if mode-require-final-newline is tru...

### DIFF
--- a/feature-mode.el
+++ b/feature-mode.el
@@ -377,7 +377,8 @@ back-dent the line by `feature-indent-offset' spaces.  On reaching column
 
 (defun feature-mode-variables ()
   (set-syntax-table feature-mode-syntax-table)
-  (setq require-final-newline t)
+  (when mode-require-final-newline
+    (setq require-final-newline t))
   (setq comment-start "# ")
   (setq comment-start-skip "#+ *")
   (setq comment-end "")


### PR DESCRIPTION
Hi there!
### Overview

I suggest to only set `require-final-newline` to `t` if `mode-require-final-newline` is true.

The documentation for the variable `mode-require-final-newline` describes it as follows:

```
Whether to add a newline at end of file, in certain major modes.
Those modes set `require-final-newline' to this value when you enable them.
They do so because they are often used for files that are supposed
to end in newlines, and the question is how to arrange that.
```

So the idea seems to be that major modes can say they want to require a final newline, but that this variable can be used (by end users) to allow or disallow that as they see fit.  It appears its original value is `t` so this should only affect end users who have explicitly switched it off (like me) - whose wishes are currently being ignored by `feature-mode.el`.
### Motivation/Background

I use the excellent [ethan-wspace](https://github.com/glasserc/ethan-wspace) to get warnings about various whitespace issues, including missing newlines at ends of files, and it requires that `require-final-newline` is nil - and complains if it isn't.  That means that (at present) every time I open a feature file, I get a warning in my `*Messages*` buffer:

```
Warning (:warning): You have `require-final-newline' turned on.
`ethan-wspace-highlight-no-nl-eof' will not work correctly. Please turn off
`require-final-newline' and `mode-require-final-newline'.
```

This is despite my `~/.emacs` containing the following lines:

```
(setq-default require-final-newline nil)
(setq-default mode-require-final-newline nil)
```
### See also...

It appears this issue is also [affecting ruby users](https://github.com/glasserc/ethan-wspace/issues/22) and the author of `ethan-space` suggests in that thread that The Right Thing to do is an upstream fix in the ruby mode.  So I'm trying to provide the same for `cucumber.el`. :-)  The alternative (for end users) is to override it in a hook but that seems suboptimal given the existence of `mode-require-final-newline` which is for exactly this purpose.

Hope you agree!

Many thanks,

-Andy
