### PR TITLE
Indent tables

### DIFF
--- a/feature-mode.el
+++ b/feature-mode.el
@@ -259,7 +259,7 @@
 (defconst feature-blank-line-re "^[ \t]*\\(?:#.*\\)?$"
   "Regexp matching a line containing only whitespace.")
 
-(defconst feature-example-line-re "^[ \t]\\\\|"
+(defconst feature-example-line-re "^[ \t]\\|"
   "Regexp matching a line containing scenario example.")
 
 (defun feature-feature-re (language)


### PR DESCRIPTION
Table editor in org mode blocks our indentor. Use advice to override that.
