### PR TITLE
Avoid disabling electric-indent-mode globally

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -16,3 +16,4 @@ Tero Tilus
 Thomas Jack
 Antono Vasiljev
 Sergey Avseyev
+Steven Rémot

--- a/feature-mode.el
+++ b/feature-mode.el
@@ -468,8 +468,8 @@ back-dent the line by `feature-indent-offset' spaces.  On reaching column
 (defun feature-minor-modes ()
   "Enable/disable all minor modes for feature mode."
   (turn-on-orgtbl)
-  (when (fboundp 'electric-indent-mode)
-    (electric-indent-mode -1)))
+  (set (make-local-variable 'electric-indent-functions)
+       (list (lambda (arg) 'no-indent))))
 
 ;;
 ;; Mode function


### PR DESCRIPTION
Currently, when a feature file is opened, feature-mode gets rid of
electric-indent-mode behaviour by disabling it. However, as it is a
global mior mode, this has the effect to disable it globally.

This commit removes the deactivation, and instead configure it so that
it does not indent anything.
