### PR TITLE
Update README to include installation of ruby_parser Gem.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ Load feature-mode
 
 ## Key Bindings
 
+In order to get goto-step-definition to work, you must install the ruby_parser gem (version 2.0.x).For example:
+
+```
+gem install ruby_parser --version=2.0.5
+```
+
 Keybinding          | Description
 --------------------|------------------------------------------------------------
 <kbd>C-c ,v</kbd>   | Verify all scenarios in the current buffer file.


### PR DESCRIPTION
Hi, I just update README to include the ruby_parser gem installation. Once it only is cited on source code, I believe is a good idea keep this kind of information more visible.

thanks
