### PR TITLE
Change regex for highlighting placeholders.

### DIFF
--- a/feature-mode.el
+++ b/feature-mode.el
@@ -219,7 +219,7 @@
     (but        . font-lock-keyword-face)
     (and        . font-lock-keyword-face)
     (examples   . font-lock-keyword-face)
-    ("<.*>"     . font-lock-variable-name-face)
+    ("<[^>]*>"  . font-lock-variable-name-face)
     ("^ *@.*"   . font-lock-preprocessor-face)
     ("^ *#.*"     0 font-lock-comment-face t)))
 


### PR DESCRIPTION
Previous regex would highlight everything between two placeholders on
the same line. New regex should highlight correctly.