### PR TITLE
Table and pystring indentation support plus some additional tweaks

### DIFF
--- a/feature-mode.el
+++ b/feature-mode.el
@@ -89,6 +89,11 @@
   :group 'feature-mode
   :type 'string)
 
+(defcustom feature-enable-back-denting t
+  "when enabled, subsequent pressing the tab key back-dents the current line by `feature-indent-offset' spaces"
+  :type 'boolean
+  :group 'feature-mode)
+
 (defcustom feature-use-rvm nil
   "t when RVM is in use. (Requires rvm.el)"
   :type 'boolean
@@ -477,7 +482,7 @@ back-dent the line by `feature-indent-offset' spaces.  On reaching column
     (save-excursion
       (beginning-of-line)
       (delete-horizontal-space)
-      (if (and (equal last-command this-command) (/= ci 0))
+      (if (and (equal last-command this-command) (/= ci 0) feature-enable-back-denting)
           (indent-to (* (/ (- ci 1) feature-indent-offset) feature-indent-offset))
         (indent-to need)))
     (if (< (current-column) (current-indentation))

--- a/feature-mode.el
+++ b/feature-mode.el
@@ -264,6 +264,9 @@
 (defconst feature-example-line-re "^[ \t]*|"
   "Regexp matching a line containing scenario example.")
 
+(defconst feature-tag-line-re "^[ \t]*@"
+  "Regexp matching a tag/annotation")
+
 (defun feature-feature-re (language)
   (cdr (assoc 'feature (cdr (assoc language feature-keywords-per-language)))))
 
@@ -360,16 +363,22 @@
             (feature-search-for-regex-match (lambda () (looking-at (feature-feature-re lang))))
             (current-indentation)
             ))
-         ((or (looking-at (feature-background-re lang)) (looking-at (feature-scenario-re lang)))
+         ((or (looking-at (feature-background-re lang))
+              (looking-at (feature-scenario-re lang))
+              (looking-at feature-tag-line-re))
           (progn
             (feature-search-for-regex-match
              (lambda () (or (looking-at (feature-feature-re lang))
+                            (looking-at feature-tag-line-re)
                             (looking-at (feature-background-re lang))
                             (looking-at (feature-scenario-re lang)))))
             (cond
-             ((looking-at (feature-feature-re lang)) (+ (current-indentation) feature-indent-level))
+             ((or (looking-at (feature-feature-re lang))
+                  (looking-at feature-tag-line-re)
+                  ) feature-indent-level)
              ((or (looking-at (feature-background-re lang))
-                  (looking-at (feature-scenario-re lang))) (current-indentation))
+                  (looking-at (feature-scenario-re lang))
+                  ) (current-indentation))
              (t saved-indentation))
             ))
          ((looking-at (feature-examples-re lang))

--- a/feature-mode.el
+++ b/feature-mode.el
@@ -367,7 +367,7 @@
                             (looking-at (feature-background-re lang))
                             (looking-at (feature-scenario-re lang)))))
             (cond
-             ((looking-at (feature-feature-re lang)) (+ (current-indentation) feature-indent-offset))
+             ((looking-at (feature-feature-re lang)) (+ (current-indentation) feature-indent-level))
              ((or (looking-at (feature-background-re lang))
                   (looking-at (feature-scenario-re lang))) (current-indentation))
              (t saved-indentation))

--- a/feature-mode.el
+++ b/feature-mode.el
@@ -272,6 +272,9 @@
 (defconst feature-tag-line-re "^[ \t]*@"
   "Regexp matching a tag/annotation")
 
+(defconst feature-pystring-re "^[ \t]*\"\"\"$"
+  "Regexp matching a pystring")
+
 (defun feature-feature-re (language)
   (cdr (assoc 'feature (cdr (assoc language feature-keywords-per-language)))))
 
@@ -435,7 +438,7 @@
               (current-indentation))
              (t saved-indentation))
             ))
-         ((looking-at feature-example-line-re)
+         ((or (looking-at feature-example-line-re) (looking-at feature-pystring-re))
           (progn
             (feature-search-for-regex-match
              (lambda () (or (looking-at (feature-examples-re lang))
@@ -453,7 +456,8 @@
                   (looking-at (feature-and-re lang))
                   (looking-at (feature-but-re lang)))
               (+ (current-indentation) feature-indent-offset))
-             ((looking-at feature-example-line-re)
+             ((or (looking-at feature-example-line-re)
+                  (looking-at feature-pystring-re))
               (current-indentation))
              (t saved-indentation))
             ))

--- a/feature-mode.el
+++ b/feature-mode.el
@@ -261,7 +261,7 @@
 (defconst feature-blank-line-re "^[ \t]*\\(?:#.*\\)?$"
   "Regexp matching a line containing only whitespace.")
 
-(defconst feature-example-line-re "^[ \t]\\\\|"
+(defconst feature-example-line-re "^[ \t]*|"
   "Regexp matching a line containing scenario example.")
 
 (defun feature-feature-re (language)

--- a/feature-mode.el
+++ b/feature-mode.el
@@ -279,6 +279,21 @@
 (defun feature-background-re (language)
   (cdr (assoc 'background (cdr (assoc language feature-keywords-per-language)))))
 
+(defun feature-given-re (language)
+  (cdr (assoc 'given (cdr (assoc language feature-keywords-per-language)))))
+
+(defun feature-when-re (language)
+  (cdr (assoc 'when (cdr (assoc language feature-keywords-per-language)))))
+
+(defun feature-then-re (language)
+  (cdr (assoc 'then (cdr (assoc language feature-keywords-per-language)))))
+
+(defun feature-and-re (language)
+  (cdr (assoc 'and (cdr (assoc language feature-keywords-per-language)))))
+
+(defun feature-but-re (language)
+  (cdr (assoc 'but (cdr (assoc language feature-keywords-per-language)))))
+
 ;;
 ;; Variables
 ;;
@@ -390,13 +405,52 @@
                 (+ (current-indentation) feature-indent-offset)
               saved-indentation)
             ))
+         ((or (looking-at (feature-given-re lang))
+              (looking-at (feature-when-re lang))
+              (looking-at (feature-then-re lang))
+              (looking-at (feature-and-re lang))
+              (looking-at (feature-but-re lang)))
+          (progn
+            (feature-search-for-regex-match
+             (lambda () (or (looking-at (feature-background-re lang))
+                            (looking-at (feature-scenario-re lang))
+                            (looking-at (feature-given-re lang))
+                            (looking-at (feature-when-re lang))
+                            (looking-at (feature-then-re lang))
+                            (looking-at (feature-and-re lang))
+                            (looking-at (feature-but-re lang)))))
+            (cond
+             ((or (looking-at (feature-background-re lang)) (looking-at (feature-scenario-re lang)))
+              (+ (current-indentation) feature-indent-offset))
+             ((or (looking-at (feature-given-re lang))
+                  (looking-at (feature-when-re lang))
+                  (looking-at (feature-then-re lang))
+                  (looking-at (feature-and-re lang))
+                  (looking-at (feature-but-re lang)))
+              (current-indentation))
+             (t saved-indentation))
+            ))
          ((looking-at feature-example-line-re)
           (progn
             (feature-search-for-regex-match
-             (lambda () (looking-at (feature-examples-re lang))))
-            (if (looking-at (feature-examples-re lang))
-                (+ (current-indentation) feature-indent-offset)
-              saved-indentation)
+             (lambda () (or (looking-at (feature-examples-re lang))
+                            (looking-at (feature-given-re lang))
+                            (looking-at (feature-when-re lang))
+                            (looking-at (feature-then-re lang))
+                            (looking-at (feature-and-re lang))
+                            (looking-at (feature-but-re lang))
+                            (looking-at feature-example-line-re))))
+            (cond
+             ((or (looking-at (feature-examples-re lang))
+                  (looking-at (feature-given-re lang))
+                  (looking-at (feature-when-re lang))
+                  (looking-at (feature-then-re lang))
+                  (looking-at (feature-and-re lang))
+                  (looking-at (feature-but-re lang)))
+              (+ (current-indentation) feature-indent-offset))
+             ((looking-at feature-example-line-re)
+              (current-indentation))
+             (t saved-indentation))
             ))
          (t
           (progn

--- a/feature-mode.el
+++ b/feature-mode.el
@@ -192,17 +192,17 @@
 (defconst feature-keywords-per-language
   (if (file-readable-p feature-default-i18n-file)
       (load-gherkin-i10n feature-default-i18n-file)
-  '(("en" . ((feature    . "^ *\\(Feature\\):?")
-             (background . "^ *\\(Background\\):?")
-             (scenario   . "^ *\\(Scenario\\):?")
+  '(("en" . ((feature    . "^ *\\(Feature\\):")
+             (background . "^ *\\(Background\\):")
+             (scenario   . "^ *\\(Scenario\\):")
              (scenario_outline .
-                           "^ *\\(Scenario Outline\\):?")
-             (given      . "^ *\\(Given\\)")
-             (when       . "^ *\\(When\\)")
-             (then       . "^ *\\(Then\\)")
-             (but        . "^ *\\(But\\)")
-             (and        . "^ *\\(And\\)")
-             (examples   . "^ *\\(Examples\\|Scenarios\\):?"))))))
+                           "^ *\\(Scenario Outline\\):")
+             (given      . "^ *\\(Given\\) ")
+             (when       . "^ *\\(When\\) ")
+             (then       . "^ *\\(Then\\) ")
+             (but        . "^ *\\(But\\) ")
+             (and        . "^ *\\(And\\) ")
+             (examples   . "^ *\\(Examples\\|Scenarios\\):"))))))
 
 (defconst feature-font-lock-keywords
   '((feature      (0 font-lock-keyword-face)

--- a/snippets/feature-mode/bac
+++ b/snippets/feature-mode/bac
@@ -4,5 +4,4 @@
 # expand-env: ((yas-indent-line 'fixed))
 # --
 Background:
-  Given ${1: a known starting condition}
-  $0
+  giv$0

--- a/snippets/feature-mode/exa
+++ b/snippets/feature-mode/exa
@@ -1,0 +1,6 @@
+# -*- mode: snippet -*-
+# key: exa
+# name: Examples
+# --
+Examples:
+  | ${1:column_title} $0

--- a/snippets/feature-mode/fea
+++ b/snippets/feature-mode/fea
@@ -4,7 +4,8 @@
 # expand-env: ((yas-indent-line 'fixed))
 # --
 Feature: ${1:Name}
-  In order to ${2:get some business value}
-  ${3:Role} will need ${4:this sweet new feature}
+  As a ${2:role}
+  I need ${3:this feature}
+  So that ${4:I get some value}
 
-  $0
+sce$0

--- a/snippets/feature-mode/giv
+++ b/snippets/feature-mode/giv
@@ -3,4 +3,4 @@
 # name: Given a known starting condition
 # --
 Given ${1:a known starting condition}
-$0
+whe$0

--- a/snippets/feature-mode/sce
+++ b/snippets/feature-mode/sce
@@ -4,4 +4,4 @@
 # expand-env: ((yas-indent-line 'fixed))
 # --
 Scenario: ${1:Name}
-  $0
+  giv$0

--- a/snippets/feature-mode/whe
+++ b/snippets/feature-mode/whe
@@ -3,4 +3,4 @@
 # name: When some action
 # --
 When ${1:some action}
-$0
+the$0


### PR DESCRIPTION
This request includes multiple commits for better support of various elements of feature files, plus allowing customization of some indentation behavior. Also included are my preferred changes to the snippets, which could be excluded from this pull request if desired. Most of the other changes build upon each other and aren't as easily disassociated.

Here is a feature file that summarizes most of the changes in this pull request:

```feature
Feature: Indentation support
  As an emacs user
  I need a feature mode that properly indents Gherkin
  So that I can more easily write feature files

Scenario: Custom scenario indent-level
  Given "feature-indent-level" set to 0
  When the file is indented
  Then the scenarios are at the same level as the feature

Scenario: Disable back-dent mode
  Given "feature-enable-back-denting" is set to "nil"
  When I press tab on a line
  And I press tab on the same line
  Then it keeps the line's indentation at the max

Scenario: Pystring support
  Given a pystring:
    """
    example pystring 1
    """
  And another pystring:
    """
    example pystring 2
    """
  When the file is indented
  Then the pystrings are indented under their steps

Scenario: Step table support
  Given a table:
    | column |
    | data 1 |
  And another table:
    | column |
    | data 2 |
  When the file is indented
  Then the tables are indented under their steps

@tag1
@tag2
Scenario: Tag support
  Given a scenario prefixed with some tags
  When the file is indented
  Then the tags are at the same indent level as the scenario

Scenario Outline: Examples table support
  Given a scenario with examples <param1> and <param2>
  When the file is indented
  Then the example table is indented under "Examples:"

  Examples:
    | param1 | param2 |
    | foo    | bar    |
    | baz    | bat    |
```