### PR TITLE
Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM ruby:2.4.1
+RUN apt-get update -qq && apt-get install -y emacs24-nox
+
+# install docker
+RUN apt-get install -y apt-transport-https ca-certificates curl gnupg2 software-properties-common
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
+RUN add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable"
+RUN apt-get update && apt-get install -y docker-ce
+
+ENV APP_HOME /myapp
+RUN mkdir $APP_HOME
+WORKDIR $APP_HOME
+
+ENV BUNDLE_GEMFILE=$APP_HOME/Gemfile \
+  BUNDLE_JOBS=2 \
+  BUNDLE_PATH=/bundle

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ If the project path contains a docker-compose.yml file, Cucumber is executed thr
 The following variables can be set to change the behavior related too this:
 
 Variable                           |  Type   | Description
------------------------------------------------------------------------------------------
+-----------------------------------|---------|-------------------------------------------
 `feature-use-docker-compose`       | boolean | Use docker-compose when available
 `feature-docker-compose-command`   | string  | The docker-compose command to execute
 `feature-docker-compose-container` | string  | Name of the container to start Cucumber in

--- a/README.md
+++ b/README.md
@@ -80,6 +80,18 @@ Keybinding          | Description
 At the moment, Cucumber.el supports whatever your Cucumber supports.
 Just configure it to load i18n.yml from your Gherkin gem sources.
 
+## Support for docker-compose
+
+If the project path contains a docker-compose.yml file, Cucumber is executed through docker-compose.
+
+The following variables can be set to change the behavior related too this:
+
+Variable                           |  Type   | Description
+-----------------------------------------------------------------------------------------
+`feature-use-docker-compose`       | boolean | Use docker-compose when available
+`feature-docker-compose-command`   | string  | The docker-compose command to execute
+`feature-docker-compose-container` | string  | Name of the container to start Cucumber in
+
 ## Project Development / Maintenance
 
 To run the tests in the source project, do the following:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '2'
+services:
+  app:
+    build: .
+    command: bundle exec cucumber -t ~@wip
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - bundle:/bundle
+      - .:/myapp
+
+volumes:
+  bundle: {}

--- a/feature-mode.el
+++ b/feature-mode.el
@@ -137,6 +137,21 @@
   :type 'string
   :group 'feature-mode)
 
+;; Docker related
+(defcustom feature-use-docker-compose t
+  "Use docker-compose when docker-compose.yml exists in project."
+  :type 'boolean
+  :group 'feature-mode)
+
+(defcustom feature-docker-compose-command "docker-compose"
+  "Command to run docker-compose."
+  :type 'string
+  :group 'feature-mode)
+
+(defcustom feature-docker-compose-container "app"
+  "The container to run cucumber in."
+  :type 'string
+  :group 'feature-mode)
 
 ;;
 ;; Keywords and font locking
@@ -647,14 +662,20 @@ are loaded on startup.  If nil, don't load snippets.")
   (and (project-file-exists "Gemfile")
        (executable-find "bundle")))
 
+(defun should-run-docker-compose ()
+  "Determines if docker-compose should be used."
+  (and (project-file-exists "docker-compose.yml")
+       feature-use-docker-compose))
+
 (defun construct-cucumber-command (command-template opts-str feature-arg)
   "Creates a complete command to launch cucumber"
   (let ((base-command
          (concat (replace-regexp-in-string
                   "{options}" opts-str
                   (replace-regexp-in-string "{feature}" feature-arg command-template) t t))))
-    (concat (if (can-run-bundle) "bundle exec " "")
-            base-command)))
+    (concat (if (should-run-docker-compose) (concat feature-docker-compose-command " run " feature-docker-compose-container " ") "")
+            (concat (if (can-run-bundle) "bundle exec " "")
+            base-command))))
 
 (defun* feature-run-cucumber (cuke-opts &key feature-file)
   "Runs cucumber with the specified options"

--- a/feature-mode.el
+++ b/feature-mode.el
@@ -672,7 +672,9 @@ are loaded on startup.  If nil, don't load snippets.")
   (let ((base-command
          (concat (replace-regexp-in-string
                   "{options}" opts-str
-                  (replace-regexp-in-string "{feature}" feature-arg command-template) t t))))
+                  (replace-regexp-in-string "{feature}"
+                                            (if (should-run-docker-compose) (replace-regexp-in-string (feature-project-root) "" feature-arg) feature-arg)
+                                            command-template) t t))))
     (concat (if (should-run-docker-compose) (concat feature-docker-compose-command " run " feature-docker-compose-container " ") "")
             (concat (if (can-run-bundle) "bundle exec " "")
             base-command))))

--- a/features/InvokesRunner.feature
+++ b/features/InvokesRunner.feature
@@ -51,7 +51,7 @@ Feature: Invokes Runner
     When I invoke feature-verify-all-scenarios-in-buffer on "features/test.feature"
     Then the output should match:
       """
-      ^docker-compose run app rake cucumber CUCUMBER_OPTS="" FEATURE=".+test.feature"
+      ^docker-compose run app rake cucumber CUCUMBER_OPTS="" FEATURE="features/test.feature"
       """
 
   Scenario: Uses docker-compose when docker-compose.yml present but no Gemfile
@@ -62,7 +62,7 @@ Feature: Invokes Runner
     When I invoke feature-verify-all-scenarios-in-buffer on "features/test.feature"
     Then the output should match:
       """
-      ^docker-compose run app cucumber .+test.feature
+      ^docker-compose run app cucumber\s*\"features/test.feature\"
       """
 
   Scenario: Uses docker-compose with bundler exec cucumber when Gemfile and docker-compose.yml present but no Rakefile
@@ -73,7 +73,7 @@ Feature: Invokes Runner
     When I invoke feature-verify-all-scenarios-in-buffer on "features/test.feature"
     Then the output should match:
       """
-      ^docker-compose run app bundle exec cucumber .+test.feature
+      ^docker-compose run app bundle exec cucumber\s*\"features/test.feature\"
       """
 
   Scenario: Uses docker-compose with bundler exec rake when Gemfile and docker-compose.yml and Rakefile present
@@ -84,5 +84,5 @@ Feature: Invokes Runner
     When I invoke feature-verify-all-scenarios-in-buffer on "features/test.feature"
     Then the output should match:
       """
-      ^docker-compose run app bundle exec rake cucumber CUCUMBER_OPTS="" FEATURE=".+test.feature"
+      ^docker-compose run app bundle exec rake cucumber CUCUMBER_OPTS="" FEATURE="features/test.feature"
       """

--- a/features/InvokesRunner.feature
+++ b/features/InvokesRunner.feature
@@ -42,3 +42,47 @@ Feature: Invokes Runner
       """
       ^bundle exec rake cucumber CUCUMBER_OPTS="" FEATURE=".+test.feature"
       """
+
+  Scenario: Uses docker-compose with rake when docker-compose.yml and Rakefile present
+    Given an empty file "Rakefile"
+    Given an empty file "docker-compose.yml"
+    And a file "Gemfile" does not exist
+    And an empty file "features/test.feature"
+    When I invoke feature-verify-all-scenarios-in-buffer on "features/test.feature"
+    Then the output should match:
+      """
+      ^docker-compose run app rake cucumber CUCUMBER_OPTS="" FEATURE=".+test.feature"
+      """
+
+  Scenario: Uses docker-compose when docker-compose.yml present but no Gemfile
+    Given a file "Rakefile" does not exist
+    And a file "Gemfile" does not exist
+    And an empty file "docker-compose.yml"
+    And an empty file "features/test.feature"
+    When I invoke feature-verify-all-scenarios-in-buffer on "features/test.feature"
+    Then the output should match:
+      """
+      ^docker-compose run app cucumber .+test.feature
+      """
+
+  Scenario: Uses docker-compose with bundler exec cucumber when Gemfile and docker-compose.yml present but no Rakefile
+    Given a file "Rakefile" does not exist
+    And an empty file "Gemfile"
+    And an empty file "docker-compose.yml"
+    And an empty file "features/test.feature"
+    When I invoke feature-verify-all-scenarios-in-buffer on "features/test.feature"
+    Then the output should match:
+      """
+      ^docker-compose run app bundle exec cucumber .+test.feature
+      """
+
+  Scenario: Uses docker-compose with bundler exec rake when Gemfile and docker-compose.yml and Rakefile present
+    Given an empty file "Rakefile"
+    And an empty file "Gemfile"
+    And an empty file "docker-compose.yml"
+    And an empty file "features/test.feature"
+    When I invoke feature-verify-all-scenarios-in-buffer on "features/test.feature"
+    Then the output should match:
+      """
+      ^docker-compose run app bundle exec rake cucumber CUCUMBER_OPTS="" FEATURE=".+test.feature"
+      """


### PR DESCRIPTION
Added support for use of docker-compose. When `docker-compose.yml` is available and `feature-use-docker-compose` is set to `t`, `docker-compose run app` is prefixed to the Cucumber command. The docker-compose command and the name of the container to run Cucumber in can also be defined through variables.