### PR TITLE
Limit the gherkin gem version to prevent load issues

### DIFF
--- a/support/find_step.rb
+++ b/support/find_step.rb
@@ -1,7 +1,7 @@
 require 'rubygems'
 gem 'ruby_parser'
 # >= 2.11.8 because of https://github.com/cucumber/gherkin/commit/90121f513000b89fce4d24c4e7dfdae00a5b177f
-gem 'gherkin', '>= 2.11.8'
+gem 'gherkin', '>= 2.11.8', '< 4.0.0'
 
 require 'ruby_parser'
 require 'yaml'


### PR DESCRIPTION
Without the upper bound gem version, `feature-goto-step-definition` fails with something like:

```lang=ruby
An error occured: 
/usr/local/lib/ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:135:in `require': cannot load such file -- gherkin (LoadError)
	from /usr/local/lib/ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:135:in `rescue in require'
	from /usr/local/lib/ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:39:in `require'
	from /.../.emacs.d/elpa/feature-mode-20170907.748/support/find_step.rb:8:in `<main>'
```