### PR TITLE
feat(match_braces): Add support for matching {type} brace placeholder…

### DIFF
--- a/support/find_step.rb
+++ b/support/find_step.rb
@@ -54,6 +54,7 @@ class Step
       when String
         pieces, regexp = [], value.dup
         regexp.gsub!(/\$\w+/) { |match| pieces << match; "TOKEN" }
+        regexp.gsub!(/(?=\{)(.*?)(\})/, "TOKEN")
         regexp = Regexp.escape(regexp)
         regexp.gsub!(/TOKEN/) { |match| "(.*)" }
         Regexp.new("^#{regexp}$")


### PR DESCRIPTION
…s in newer cucumber

I am using feature-mode with a newer version of cucumber where brace placeholders are the preferred method of type substitution (e.g. `{word}`, `{string}`, `{int}`). This PR simply converts those placeholders into `TOKEN` in the existing logic, which causes them to be replaced with `(.*)` regex and matched against corresponding step definitions. 

I ran the tests and verified they still pass per the README, and this works correctly per my expectations on my local system.